### PR TITLE
Change class from TBSMagritteReport to TBPostsReport

### DIFF
--- a/Chapters/Chap08-TinyBlog-Admin-FR.pillar
+++ b/Chapters/Chap08-TinyBlog-Admin-FR.pillar
@@ -299,12 +299,12 @@ TBSMagritteReport subclass: #TBPostsReport
 ]]]
 
 [[[
-TBSMagritteReport >> blog
+TBPostsReport >> blog
    ^ blog
 ]]]
 
 [[[
-TBSMagritteReport >> blog: aTBBlog
+TBPostsReport >> blog: aTBBlog
    blog := aTBBlog
 ]]]
 


### PR DESCRIPTION
Methods marked as
TBSMagritteReport  >> blog 
TBSMagritteReport  >> blog: aTBBlog

are improved if marked as
TBPostsReport >> blog 
TBPostsReport >> blog: aTBBlog